### PR TITLE
Moved about + join headlines into sections

### DIFF
--- a/about/index.qmd
+++ b/about/index.qmd
@@ -39,9 +39,19 @@ format:
 </div>
 ```
 
-Our team combines experience building and scaling complex systems at Stripe, Twitter, and Google X with a research foundation from MIT in probabilistic modeling, GPU inference, and neuroscience. Our goal is to make physical AI practical, reliable, and simple to integrate, so you can focus on deploying systems that work seamlessly in the real world.
-
 ::: {.ethos-content}
+::: {.content-section}
+::: {.column-page}
+::: {.section-divider}
+[About]{.section-title}
+:::
+:::
+::: {.grid}
+::: {.g-col-12}
+Our team combines experience building and scaling complex systems at Stripe, Twitter, and Google X with a research foundation from MIT in probabilistic modeling, GPU inference, and neuroscience. Our goal is to make physical AI practical, reliable, and simple to integrate, so you can focus on deploying systems that work seamlessly in the real world.
+:::
+:::
+:::
 ::: {.content-section}
 ::: {.column-page}
 ::: {.section-divider}

--- a/join/index.qmd
+++ b/join/index.qmd
@@ -51,7 +51,6 @@ format:
 If you’re excited to shape the next generation of intelligent systems, we’d love to hear from you. Get in touch with us at <a href="mailto:jobs@perceptual.ai">jobs@perceptual.ai</a>.
 :::
 :::
-:::
 ::: {.content-section} 
 ::: {.column-page}
 ::: {.section-divider}

--- a/join/index.qmd
+++ b/join/index.qmd
@@ -39,9 +39,19 @@ format:
 </div>
 ```
 
-If you’re excited to shape the next generation of intelligent systems, we’d love to hear from you. Get in touch with us at <a href="mailto:jobs@perceptual.ai">jobs@perceptual.ai</a>.
-
 ::: {.ethos-content}
+::: {.content-section}
+::: {.column-page}
+::: {.section-divider}
+[Join]{.section-title}
+:::
+:::
+::: {.grid}
+::: {.g-col-12}
+If you’re excited to shape the next generation of intelligent systems, we’d love to hear from you. Get in touch with us at <a href="mailto:jobs@perceptual.ai">jobs@perceptual.ai</a>.
+:::
+:::
+:::
 ::: {.content-section} 
 ::: {.column-page}
 ::: {.section-divider}


### PR DESCRIPTION
Zero content changes. Moves the headline for about and join into a proper section for some visual anchoring.